### PR TITLE
Made a script that generates a new profile via command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 A Magisk/KernelSU/APatch module for spoofing device identity properties. Spoofs device identity toward a Google Pixel 7 Pro profile with persona management. Best if used with [DeviceSpoofLab-Hooks](https://github.com/yubunus/DeviceSpoofLab-Hooks)
 
+## Generate new profile
+
+```bash
+adb shell
+su
+devicespooflabsnew
+```
+
 ## Features
 
 1. **Interactive CLI** (`devicespooflabs` command)

--- a/common/devicespooflabs.sh
+++ b/common/devicespooflabs.sh
@@ -564,6 +564,8 @@ handle_app_tools_menu() {
 main() {
     check_root
     check_module
+	
+	if [ $# -eq 0 ]; then
 
     # Main menu loop
     while true; do
@@ -587,6 +589,21 @@ main() {
                 ;;
         esac
     done
+    exit 0
+	fi
+	
+
+	case "$1" in
+		1)
+			regenerate_identifiers
+			activate_persona
+			;;
+		*)
+			exit 1
+			;;
+	esac
+
+    
 }
 
 main "$@"

--- a/customize.sh
+++ b/customize.sh
@@ -30,7 +30,8 @@ set_permissions() {
     ui_print "- Setting permissions"
     set_perm_recursive "$MODPATH" 0 0 0755 0644
     set_perm_recursive "$MODPATH/common" 0 0 0755 0755
-    set_perm "$MODPATH/system/bin/devicespooflabs" 0 2000 0755
+        set_perm "$MODPATH/system/bin/devicespooflabs" 0 2000 0755
+    set_perm "$MODPATH/system/bin/devicespooflabsnew" 0 2000 0755
     set_perm "$MODPATH/post-fs-data.sh" 0 0 0755
     set_perm "$MODPATH/service.sh" 0 0 0755
 }

--- a/customize.sh
+++ b/customize.sh
@@ -5,7 +5,7 @@ SKIPUNZIP=0
 
 ui_print " "
 ui_print "********************************"
-ui_print "   DeviceSpoofLabs v2.3"
+ui_print "   DeviceSpoofLabs v2.3.1"
 ui_print "********************************"
 ui_print " "
 
@@ -30,7 +30,7 @@ set_permissions() {
     ui_print "- Setting permissions"
     set_perm_recursive "$MODPATH" 0 0 0755 0644
     set_perm_recursive "$MODPATH/common" 0 0 0755 0755
-        set_perm "$MODPATH/system/bin/devicespooflabs" 0 2000 0755
+	set_perm "$MODPATH/system/bin/devicespooflabs" 0 2000 0755
     set_perm "$MODPATH/system/bin/devicespooflabsnew" 0 2000 0755
     set_perm "$MODPATH/post-fs-data.sh" 0 0 0755
     set_perm "$MODPATH/service.sh" 0 0 0755

--- a/system/bin/devicespooflabsnew
+++ b/system/bin/devicespooflabsnew
@@ -1,0 +1,2 @@
+#!/system/bin/sh
+exec /data/adb/modules/devicespooflab/common/devicespooflabs.sh "1"


### PR DESCRIPTION
I find it inconvenient to use the interactive interface of your CLI, and I decided to make a script for programmatically creating a new profile.

Using:

## Generate new profile

```bash
adb shell
su
devicespooflabsnew
```